### PR TITLE
Added an example for exhaustMap

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -22,6 +22,7 @@ export class AppComponent {
     { path: '/examples/11-map', name: 'Map'},
     { path: '/examples/12-annotate', name: 'Annotate'},
     { path: '/examples/13-game', name: 'Game'},
-    { path: '/examples/14-slider', name: 'Slider'}
+    { path: '/examples/14-slider', name: 'Slider'},
+    { path: '/examples/15-wait-for-stream', name: 'Wait for Stream'}
   ];
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -44,12 +44,21 @@ import {
   GameMasterComponent,
   SliderComponent,
   SliderClientComponent,
-  SliderMasterComponent
+  SliderMasterComponent,
+  WaitForStreamComponent
 } from './examples';
 import { AngularFirestoreModule } from 'angularfire2/firestore';
 import { AngularFireDatabase, AngularFireDatabaseModule } from 'angularfire2/database';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatButtonModule, MatCardModule, MatIconModule, MatListModule, MatSidenavModule, MatToolbarModule } from '@angular/material';
+import {
+  MatButtonModule,
+  MatCardModule,
+  MatIconModule, MatInputModule,
+  MatListModule,
+  MatSelectModule,
+  MatSidenavModule,
+  MatToolbarModule
+} from '@angular/material';
 
 @NgModule({
   declarations: [
@@ -87,7 +96,8 @@ import { MatButtonModule, MatCardModule, MatIconModule, MatListModule, MatSidena
     GameMasterComponent,
     SliderComponent,
     SliderClientComponent,
-    SliderMasterComponent
+    SliderMasterComponent,
+    WaitForStreamComponent
   ],
   imports: [
     BrowserModule,
@@ -102,6 +112,8 @@ import { MatButtonModule, MatCardModule, MatIconModule, MatListModule, MatSidena
     MatListModule,
     MatSidenavModule,
     MatToolbarModule,
+    MatSelectModule,
+    MatInputModule,
     routing
   ],
   providers: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -55,7 +55,6 @@ import {
   MatCardModule,
   MatIconModule, MatInputModule,
   MatListModule,
-  MatSelectModule,
   MatSidenavModule,
   MatToolbarModule
 } from '@angular/material';
@@ -112,7 +111,6 @@ import {
     MatListModule,
     MatSidenavModule,
     MatToolbarModule,
-    MatSelectModule,
     MatInputModule,
     routing
   ],

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -15,7 +15,7 @@ import {
   MapComponent,
   AnnotateComponent,
   GameComponent,
-  SliderComponent
+  SliderComponent, WaitForStreamComponent
 } from './examples';
 
 const appRoutes: Routes = [
@@ -38,7 +38,8 @@ const appRoutes: Routes = [
   { path: 'examples/11-map', component: MapComponent },
   { path: 'examples/12-annotate', component: AnnotateComponent },
   { path: 'examples/13-game', component: GameComponent },
-  { path: 'examples/14-slider', component: SliderComponent }
+  { path: 'examples/14-slider', component: SliderComponent },
+  { path: 'examples/15-wait-for-stream', component: WaitForStreamComponent }
 ];
 
 export const appRoutingProviders: any[] = [];

--- a/src/app/examples/15-wait-for-stream/books.service.ts
+++ b/src/app/examples/15-wait-for-stream/books.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable()
+export class BooksService {
+  private endpoint = 'http://openlibrary.org';
+  constructor(private http: HttpClient) {}
+
+  search(term) {
+    return this.http.get(`${this.endpoint}/search.json`, {params: {q: term}});
+  }
+}

--- a/src/app/examples/15-wait-for-stream/wait-for-stream.component.ts
+++ b/src/app/examples/15-wait-for-stream/wait-for-stream.component.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { BooksService } from './books.service';
+import { MatButton } from '@angular/material';
+import { fromEvent } from 'rxjs/index';
+import { exhaustMap, tap } from 'rxjs/internal/operators';
+import { FormControl } from '@angular/forms';
+
+@Component({
+  selector: 'app-wait-for-stream',
+  template: `
+    <mat-form-field class="search">
+      <input name="search" [formControl]="searchControl" type="search" matInput placeholder="Search Books">
+    </mat-form-field>
+    <button #search mat-raised-button color="accent">Search</button>
+    <mat-list>
+      <h3 mat-subheader>Books</h3>
+      <mat-divider></mat-divider>
+      <mat-list-item *ngFor="let book of books">
+        <h4 mat-line>{{book.title}}</h4>
+        <p mat-line> {{book.first_publish_year}} | {{book.author_name ? book.author_name[0] : ''}} </p>
+      </mat-list-item>
+    </mat-list>
+  `,
+  styles: [`
+    .search {
+      width: 100%;
+      max-width: 500px;
+      margin-left: 15px;
+    }
+    button {
+      margin-left: 15px;
+    }
+    mat-list {
+      height: 100%;
+      overflow: auto;
+    }
+  `],
+  providers: [BooksService]
+})
+export class WaitForStreamComponent implements OnInit {
+  @ViewChild('search') search: MatButton;
+
+  books;
+  searchControl: FormControl = new FormControl('');
+
+  constructor(private booksService: BooksService) { }
+
+  ngOnInit() {
+    fromEvent(this.getNativeElement(this.search), 'click')
+      .pipe(
+        exhaustMap(event => this.booksService.search(this.searchControl.value)),
+        tap((response: any) => this.books = response.docs)
+      ).subscribe();
+  }
+
+  getNativeElement(element) {
+    return element._elementRef.nativeElement;
+  }
+
+}

--- a/src/app/examples/index.ts
+++ b/src/app/examples/index.ts
@@ -35,3 +35,5 @@ export { GameMasterComponent } from './13-game/game-master.component';
 export { SliderComponent } from './14-slider/slider.component';
 export { SliderClientComponent } from './14-slider/slider-client.component';
 export { SliderMasterComponent } from './14-slider/slider-master.component';
+
+export { WaitForStreamComponent } from './15-wait-for-stream/wait-for-stream.component';


### PR DESCRIPTION
I created an example that essentially binds to the `click` event of a search button, then uses `exhaustMap` to "ignore" all other button clicks until the search network request is finished. At that point, it would make requests again. This is a common use case that guards against unwanted network requests. This example will probably involve looking at the network tab, if you think it's too much, we can scale it back.